### PR TITLE
`advanced_config.py` bug fix

### DIFF
--- a/py/advanced_config.py
+++ b/py/advanced_config.py
@@ -1303,8 +1303,6 @@ def main():
 
     args = parser.parse_args()
 
-    if args.apply_restraint_group_to_each_chain and not args.chain_break_from_file:
-        parser.error('--apply-restraint-group-to-each-chain requires --chain-break-from-file')
 
     global n_atom, t, potential
     t = tb.open_file(args.config,'a')
@@ -1344,6 +1342,9 @@ def main():
         if 'rl_chains' in t.root.input.chain_break:
             has_rl_info = True
             rl_chains = t.root.input.chain_break.rl_chains[:]
+
+    if args.apply_restraint_group_to_each_chain and ('chain_break' not in t.root.input): 
+        parser.error('--apply-restraint-group-to-each-chain in advanced_config requires --chain-break-from-file in upside_config')
 
     if args.heuristic_cavity_radius:
         if n_chains < 2:

--- a/py/run_upside.py
+++ b/py/run_upside.py
@@ -50,7 +50,6 @@ def upside_config(fasta,
                   target_structure='',
                   chain_break_from_file='',
                   cavity_radius=0.,
-                  make_unbound=False,
                   intensive_memory= False,
 
                   bond_stiffness=None,
@@ -164,10 +163,6 @@ def upside_config(fasta,
 
     if chain_break_from_file:
         args.append('--chain-break-from-file=%s'%chain_break_from_file)
-    if cavity_radius:
-        args.append('--cavity-radius=%f'%cavity_radius)
-    if make_unbound:
-        args.append('--make-unbound')
 
     if surface:
         args.append('--surface')
@@ -258,6 +253,7 @@ def advanced_config(config,
                   secstr_bias='',
                   chain_break_from_file='',
                   apply_restraint_group_to_each_chain=False,
+                  make_unbound=False,
                   cavity_radius=0.,
                   heuristic_cavity_radius=None,
                   cavity_radius_from_config='',):
@@ -325,6 +321,8 @@ def advanced_config(config,
         args.append('--apply-restraint-group-to-each-chain')
     if cavity_radius:
         args.append('--cavity-radius=%f'%cavity_radius)
+    if make_unbound:
+        args.append('--make-unbound')
     if heuristic_cavity_radius:
         args.append('--heuristic-cavity-radius=%f'%heuristic_cavity_radius)
     if cavity_radius_from_config:


### PR DESCRIPTION
Two bugs are fixed due to the split of upside_config and advanced_config:
1. in `run_upside.py`, `make-bound` should belong to `advanced_config`
2. in `advanced_config.py`, the reference for `chain_break_from_file` argument should be changed, as `chain_break_from_file` option stays in `upside_config.py`