### PR TITLE
fix python3 issue with bytes vs. utf-8

### DIFF
--- a/py/extract_vtf.py
+++ b/py/extract_vtf.py
@@ -131,7 +131,7 @@ def main():
         top_file = args.top_h5
 
     with tables.open_file(top_file) as t:
-        seq = t.root.input.sequence[:]
+        seq = np.char.decode(t.root.input.sequence[:], encoding='UTF-8')
         if 'chain_break' in t.root.input:
             chain_first_residue = t.root.input.chain_break.chain_first_residue[:]
         else:


### PR DESCRIPTION
- fixes issues where the amino acid sequence ("seq") is loaded in an ndarray of byte strings. This is denoted as b'AA' where AA would be the three-letter amino acid code. Since the whole file uses utf-8 encoding, I adjusted the code so that the sequence ndarray is converted to utf-8 for each amino acid.