### PR TITLE
Update example scripts for restarting simulations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,6 @@ CMakeFiles/
 .ycm_extra_conf.py
 compile_commands.json
 source.sh
+**inputs/
+**outputs/
 

--- a/example/12.MultistepIntegrator/0.run.py
+++ b/example/12.MultistepIntegrator/0.run.py
@@ -29,7 +29,7 @@ base_dir       = './'
 
 input_dir  = "{}/inputs".format(base_dir)
 output_dir = "{}/outputs".format(base_dir)
-run_dir    = "{}/{}".format(output_dir, sim_id) 
+run_dir    = "{}/{}".format(output_dir, sim_id)
 
 make_dirs = [input_dir, output_dir, run_dir]
 for direc in make_dirs:

--- a/example/13.RestartSimulation/0.continue.py
+++ b/example/13.RestartSimulation/0.continue.py
@@ -25,7 +25,7 @@ duration       = 1000
 frame_interval = 1
 base_dir       = './'
 
-continue_sim     = False  # when you run a new simulation, set it as "False"
+continue_sim     = True  # when you run a new simulation, set it as "False"
                          # "True" means restarting the simulation from the last frame
                          # of the previous trajectories (they should have the same 
                          # pdb_id and sim_id as the new simulation, and exist in the 

--- a/example/13.RestartSimulation/README.md
+++ b/example/13.RestartSimulation/README.md
@@ -2,11 +2,11 @@ Restart an Upside Simulation Properly
 
 # Procedures
 1. first run `0.run.py` for 1000 steps
-2. change the variable `continue_sim` from `False` to `True` in line 28.
-3. run `0.run.py` again, upside will correctly load the end configuration and the end momentum to properly restart the trajectory. 
+2. run `0.continue.py`, upside will correctly load the end configuration and the end momentum to properly restart the trajectory. (the only difference between `0.run.py` and `0.continue.py` is line 28 is changed to `continue_sim=True`).
+
 
 # Explanation
 1. in the first run, we call upside with the argument `--record-momentum` so that momenta recorded.
-2. in the `0.run.py`, line 204, if the `continue_sim=True`, the python script will copy the configuration and the momentum of the end frame as the input position and momentum. 
-3. in the `0.run.py`, if the `continue_sim=True`, the python script will call upside with the argument `--restart-using-momentum`
+2. in the `0.continue.py`, line 28, with `continue_sim=True`, the python script will copy the configuration and the momentum of the end frame as the input position and momentum. 
+3. in the `0.continue.py`, with `continue_sim=True`, the python script will call upside with the argument `--restart-using-momentum`
 


### PR DESCRIPTION
the overwriting problem is fixed by adding a check for node mom under t.input and then remove the previous mom